### PR TITLE
PublishDir set to move for Singularity containers

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -81,7 +81,7 @@ dockerContainersBuilt = dockerContainersBuilt.view {"Docker container: $reposito
 process PullSingularityContainers {
   tag {repository + "/" + container + ":" + tag}
 
-  publishDir singularityPublishDir, mode: 'copy'
+  publishDir singularityPublishDir, mode: 'move'
 
   input:
     val container from singularityContainers


### PR DESCRIPTION
Definitvely don't need to use `copy` since it will take twice as space, and we just need to run it once.