### PR TITLE
Reduce Docker image size

### DIFF
--- a/containers/htslib/Dockerfile
+++ b/containers/htslib/Dockerfile
@@ -1,32 +1,11 @@
-FROM debian:8.6
+FROM alpine:3.6
 
 LABEL author="Maxime Garcia" \
 description="HTSlib 1.4 image for use in CAW" \
 maintainer="maxime.garcia@scilifelab.se"
 
-# Install libraries
-RUN apt-get update && apt-get install -y --no-install-recommends \
-build-essential \
-ca-certificates \
-curl \
-libbz2-dev \
-liblzma-dev \
-libncurses5-dev \
-libncursesw5-dev \
-zlib1g-dev \
-&& rm -rf /var/lib/apt/lists/*
-
-# Setup ENV variables
-ENV HTSLIB_BIN="htslib-1.4.tar.bz2" \
-HTSLIB_VERSION="1.4"
-
-# Install HTSlib
-RUN curl -fsSL https://github.com/samtools/htslib/releases/download/$HTSLIB_VERSION/$HTSLIB_BIN -o /opt/$HTSLIB_BIN \
-&& tar xvjf /opt/$HTSLIB_BIN -C /opt/ \
-&& cd /opt/htslib-$HTSLIB_VERSION \
-&& make \
-&& make install \
-&& rm -rf /opt/$HTSLIB_BIN /opt/htslib-$HTSLIB_VERSION
+ADD build.sh /
+RUN /build.sh
 
 # Create UPPMAX directories
 RUN mkdir /pica /proj /sw

--- a/containers/htslib/build.sh
+++ b/containers/htslib/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install libraries
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    libbz2-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    zlib1g-dev
+rm -rf /var/lib/apt/lists/*
+
+# Setup ENV variables
+HTSLIB_BIN="htslib-1.4.tar.bz2"
+HTSLIB_VERSION="1.4"
+
+# Install HTSlib
+curl -fsSL https://github.com/samtools/htslib/releases/download/$HTSLIB_VERSION/$HTSLIB_BIN -o /opt/$HTSLIB_BIN
+tar xvjf /opt/$HTSLIB_BIN -C /opt/
+cd /opt/htslib-$HTSLIB_VERSION
+make
+make install
+rm -rf /opt/$HTSLIB_BIN /opt/htslib-$HTSLIB_VERSION

--- a/containers/htslib/build.sh
+++ b/containers/htslib/build.sh
@@ -1,27 +1,17 @@
-#!/bin/bash
+#!/bin/ash
 set -euo pipefail
 
-# Install libraries
-apt-get update
-apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    curl \
-    libbz2-dev \
-    liblzma-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
-    zlib1g-dev
-rm -rf /var/lib/apt/lists/*
-
-# Setup ENV variables
-HTSLIB_BIN="htslib-1.4.tar.bz2"
-HTSLIB_VERSION="1.4"
-
-# Install HTSlib
-curl -fsSL https://github.com/samtools/htslib/releases/download/$HTSLIB_VERSION/$HTSLIB_BIN -o /opt/$HTSLIB_BIN
-tar xvjf /opt/$HTSLIB_BIN -C /opt/
-cd /opt/htslib-$HTSLIB_VERSION
+HTSLIB_VERSION=1.4
+apk --update add wget ca-certificates zlib-dev libbz2 bzip2-dev xz-dev xz-libs build-base
+mkdir /build
+cd /build
+wget --quiet -O htslib.tar.bz2 https://github.com/samtools/htslib/releases/download/$HTSLIB_VERSION/htslib-${HTSLIB_VERSION}.tar.bz2
+tar xf htslib.tar.bz2
+cd htslib-$HTSLIB_VERSION
 make
-make install
-rm -rf /opt/$HTSLIB_BIN /opt/htslib-$HTSLIB_VERSION
+make install prefix=/usr
+
+apk del wget ca-certificates zlib-dev bzip2-dev xz-dev build-base
+rm -rf /var/cache/apk/*
+cd /
+rm -rf /build


### PR DESCRIPTION
Here’s a suggestion of how the size of the Docker images could be reduced. It’s probably not a huge problem, but then why have a big image if a small one works just as well? Since these images are later converted to Singularity `.img` files, which we then need to transfer to our secret cluster, it’s also nice if it takes a couple of seconds less time.

With this change, the size of the image is reduced from 340 MB to 18 MB.

I’ve changed only the htslib Dockerfile, just to test it. I followed advice I read in the article at http://jonathan.bergknoff.com/journal/building-good-docker-images and its update at http://jonathan.bergknoff.com/journal/building-better-docker-images .